### PR TITLE
Fetcher internasjonale classifications, slug routes med navn fremfor ID.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
   const locale = "no"
 
   const getSelectedClasses = async () => {
-    await fetch(`https://app.ticketmaster.com/discovery/v2/classifications?apikey=${apiKey}&id=KZFzniwnSyZfZ7v7nJ,KZFzniwnSyZfZ7v7nE,KZFzniwnSyZfZ7v7na&locale=no`)
+    await fetch(`https://app.ticketmaster.com/discovery/v2/classifications?apikey=${apiKey}&id=KZFzniwnSyZfZ7v7nJ,KZFzniwnSyZfZ7v7nE,KZFzniwnSyZfZ7v7na&locale=*`)
     .then((response) => response.json())
     .then((data) => setSelectedClasses(data._embedded.classifications))
     

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,12 +17,13 @@ export default function Header({selectedClasses, setSelectedClasses}){
                         <ul>
                             {selectedClasses?.map((classification) => (
                                 <li key={classification.segment.id} className="classLink">
-                                <NavLink to={`category/${classification.segment.id}`}>{classification.segment.name}
+                                <NavLink to={`category/${classification.segment.name.toLowerCase()}`}>{classification.segment.name}
                                 </NavLink>
                                 </li>))}                                                        
                             <li>
                                 <LinkButton/>
                             </li>
+                            
                         </ul>
                     </nav>
                 </section>


### PR DESCRIPTION
Fetcher internasjonale classifications fremfor kun norske. Dette endrer navn på linker til å være engelsk, ellers måtte de blitt hardkodet som norske. Slug til kategori routes med navn så en kan kjøre ny endpoint request med keyword på find/suggest.